### PR TITLE
Add URL Routing for Monthly Challenges with Reverse Functionality

### DIFF
--- a/challenges/urls.py
+++ b/challenges/urls.py
@@ -2,7 +2,14 @@ from django.urls import path
 
 from . import views
 
+# URL patterns for the "challenges" app
 urlpatterns = [
+    # Route to handle numeric month input (e.g., /challenges/1, /challenges/12)
+    # This will call the 'monthly_challenge_by_number' view and pass the number as an integer
     path("<int:month>", views.monthly_challenge_by_number),
-    path("<str:month>", views.monthly_challenge),
+    
+    # Route to handle string-based month input (e.g., /challenges/january, /challenges/december)
+    # This will call the 'monthly_challenge' view and pass the month name as a string
+    # The 'name' attribute is used to reference this route elsewhere in the project (e.g., with 'reverse')
+    path("<str:month>", views.monthly_challenge, name="month-challenge"),
 ]

--- a/challenges/views.py
+++ b/challenges/views.py
@@ -1,30 +1,42 @@
 from django.shortcuts import render
 from django.http import HttpResponse, HttpResponseNotFound, HttpResponseRedirect
+from django.urls import reverse
 
-# Create your views here.
-
+# Dictionary mapping month names to challenge text
 month_challenges = {
-        "january": "January Challenge",
-        "february": "February Challenge",
-        "march": "March Challenge",
-        "april": "April Challenge",
-        "may": "May Challenge",
-        "june": "June Challenge",
-        "july": "July Challenge",
-        "august": "August Challenge",
-        "september": "September Challenge",
-        "october": "October Challenge",
-        "november": "November Challenge",
-        "december": "December Challenge",
-    }
+    "january": "January Challenge",
+    "february": "February Challenge",
+    "march": "March Challenge",
+    "april": "April Challenge",
+    "may": "May Challenge",
+    "june": "June Challenge",
+    "july": "July Challenge",
+    "august": "August Challenge",
+    "september": "September Challenge",
+    "october": "October Challenge",
+    "november": "November Challenge",
+    "december": "December Challenge",
+}
 
+# View function to handle numeric month input (e.g., /challenges/1/)
 def monthly_challenge_by_number(request, month):
+    # Convert the keys of the dictionary into a list (i.e., list of months)
     months = list(month_challenges.keys())
-    forward_month = months[month-1]
+
+    # Check if the month number is outside the valid range (1 to 12)
     if month > 12 or month < 1:
         return HttpResponseNotFound("Invalid month")
-    
-    return HttpResponseRedirect(f"/challenges/{forward_month}")
 
+    # Get the corresponding month name based on the number (1-based index)
+    redirect_month = months[month - 1]
+
+    # Generate the URL for the named route 'month-challenge' with the month name as argument
+    reverse_path = reverse("month-challenge", args=[redirect_month])
+
+    # Redirect the user to the appropriate month challenge page
+    return HttpResponseRedirect(reverse_path)
+
+# View function to handle textual month input (e.g., /challenges/january/)
 def monthly_challenge(request, month):
+    # Return the challenge text for the given month or a default error message
     return HttpResponse(month_challenges.get(month, "Invalid month"))

--- a/monthly_challenges/urls.py
+++ b/monthly_challenges/urls.py
@@ -17,7 +17,12 @@ Including another URLconf
 from django.contrib import admin
 from django.urls import path, include
 
+# List of URL patterns for the Django project
 urlpatterns = [
+    # Route to the Django admin interface
     path('admin/', admin.site.urls),
+    
+    # Include all the URL patterns from the "challenges" app under the "challenges/" base path
+    # This allows you to organize URLs in a modular way
     path("challenges/", include("challenges.urls"))
 ]


### PR DESCRIPTION
Implemented URL patterns in the challenges app to handle both numeric and string-based month inputs. 

The routes include:

A numeric route mapped to the monthly_challenge_by_number view.

A string-based route mapped to the monthly_challenge view with a named route for reverse URL resolution.

This update enhances flexibility in accessing monthly challenges and supports Django's reverse function for cleaner navigation.